### PR TITLE
Fix non existent box on Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "trusty64"
-  config.vm.box_url = "http://files.vagrantup.com/trusty64.box"
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.host_name = "cuba-skeleton"
 
   config.vm.network("forwarded_port", :guest => 80, :host => 9393)


### PR DESCRIPTION
`vagrant up` currently fails with a 404 error. Setting it to `precise64` worked.
