### PR TITLE
Invalid underscore method on ErrorNotifiers::Default

### DIFF
--- a/lib/error_notifiers/default.rb
+++ b/lib/error_notifiers/default.rb
@@ -15,14 +15,14 @@ module ErrorNotifiers
     def initialize(exception, options = {})
       @exception = exception
       @templates_path = options.fetch(:templates_path)
-      @logs_path = options.fetch(:logs_path, Dir.pwd)
+      @logs_path = options.fetch(:logs_path)
     end
 
     # Log the log_content into the logs folder.
     def log
       dirname, filename = Time.now.utc.strftime("%Y%m%d_%H%M%S%L").split("_")
       dirname = File.join(@logs_path, dirname)
-      filename = "#{self.class.name.gsub(/^.*\:/, "").underscore}_#{filename}"
+      filename = "#{self.class.name.gsub(/^.*\:/, "").downcase}_#{filename}"
       unless File.directory?(dirname)
         FileUtils.mkdir(dirname)
       end

--- a/notifiers/rack_error.text.erb
+++ b/notifiers/rack_error.text.erb
@@ -1,0 +1,23 @@
+Exception Class: <%= notifier.exception.class.to_s %>
+Exception message: <%= notifier.exception.message %>
+
+===================================================================
+Backtrace:
+===================================================================
+
+  <%= notifier.exception.backtrace.join("\n  ") %>
+
+===================================================================
+Rack Environment:
+===================================================================
+
+  ENVIRONMENT:             <%= notifier.environment %>
+  PID:                     <%= $$ %>
+  PWD:                     <%= Dir.getwd %>
+
+  Params:
+    <%= notifier.params.empty? ? "No params" : notifier.params.
+        map { |k, v| "%-23s%p" % ["#{k}:", v] }.join("\n    ") %>
+
+  <%= notifier.sanitized_env.
+      map { |k, v| "%-25s%p" % ["#{k}:", v] }.join("\n  ") %>


### PR DESCRIPTION
This PR fixes a bug of invalid `underscore` method usage on `ErrorNotifiers::Default` class. Ref #10 

Also append a generic template to `ErrorNotifiers::RackError` notifier.
