### PR TITLE
Use "a" option for logs

### DIFF
--- a/lib/error_notifiers/default.rb
+++ b/lib/error_notifiers/default.rb
@@ -26,7 +26,7 @@ module ErrorNotifiers
       unless File.directory?(dirname)
         FileUtils.mkdir(dirname)
       end
-      File.open(File.join(dirname, filename), "w") { |f| f.puts(content) }
+      File.open(File.join(dirname, filename), "a") { |f| f.puts(content) }
     end
 
     # Get the content to log.


### PR DESCRIPTION
Log file will truncate every time a message is logged.
